### PR TITLE
Require unauthenticated access

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -10,6 +10,11 @@ module Authentication
     def allow_unauthenticated_access(**options)
       skip_before_action :require_authentication, **options
     end
+
+    def require_unauthenticated_access(**options)
+      allow_unauthenticated_access(**options)
+      before_action :redirect_authenticated_users_to_root, **options
+    end
   end
 
   private
@@ -49,5 +54,9 @@ module Authentication
     def terminate_session
       Current.session.destroy
       cookies.delete(:session_id)
+    end
+
+    def redirect_authenticated_users_to_root
+      redirect_to main_app.root_path if authenticated?
     end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,6 @@
 module Users
   class SessionsController < ApplicationController
-    allow_unauthenticated_access only: %i[ new create ]
+    require_unauthenticated_access only: %i[ new create ]
     rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
     def new

--- a/test/controllers/users/sessions_controller_test.rb
+++ b/test/controllers/users/sessions_controller_test.rb
@@ -79,5 +79,14 @@ module Users
       assert_redirected_to new_session_url
       assert_not cookies[:session_id].present?
     end
+
+    test "if signed in, new session page redirects to home" do
+      post session_url, params: { email_address: "one@email.com", password: "password" }
+      assert cookies[:session_id].present?
+
+      get new_session_url
+
+      assert_redirected_to root_url
+    end
   end
 end


### PR DESCRIPTION
Some pages should only be accessible if the user is not authenticated.